### PR TITLE
Add "apt-get update" to refresh security/updates pkg index

### DIFF
--- a/.zuul/playbooks/envoy-build/run.yaml
+++ b/.zuul/playbooks/envoy-build/run.yaml
@@ -8,6 +8,7 @@
       shell:
         cmd: |
           apt update
+          apt-get update
           apt-get install -y \
              libtool \
              cmake \


### PR DESCRIPTION
The `apt update` will not update the xenial-updates and
xenial-security, so if the package in these repo will not
be refreshed when version up.

This patch add the apt-get update after apt update to make
sure the repo index is refreshed.

close: https://github.com/theopenlab/openlab/issues/285
